### PR TITLE
Remove single-quotes around condition expression

### DIFF
--- a/src/Finelines/Format.fs
+++ b/src/Finelines/Format.fs
@@ -5,14 +5,15 @@ open System
 
 // TODO: Not the best naming here as well
 
-type Input = 
+type Input =
     | Bool of bool
     | Integer of int
     | Text of string
+    | ConditionExpression of string
     | Sequence of string list
     | Dictionary of Map<string, string>
 
-let canBeUnquoted (s: string) = 
+let canBeUnquoted (s: string) =
     s |> Seq.forall (fun c -> Char.IsLetterOrDigit c || Char.IsWhiteSpace c) &&
     s |> Seq.exists Char.IsLetter
 
@@ -22,17 +23,18 @@ let rec format = function
     | Text value -> value |> function
         | _ when value |> canBeUnquoted -> $"{value}"
         | _ -> $"'{value}'"
+    | ConditionExpression value -> $"{value}"
     | Sequence value -> value |> function
         | _ when value.IsEmpty -> "''"
         | _ when value.Length = 1 -> $"{format (Text (value |> List.exactlyOne))}"
 
         // TODO: proper indenting here, not hardcoded
         | _ -> value |> List.fold (fun acc item -> $"{acc}{br}      {item}") "|"
-    | Dictionary value -> 
-        let text = 
+    | Dictionary value ->
+        let text =
             value
             |> Map.toSeq
             |> Seq.map (fun (k, v) -> $"-{k} {v}")
             |> String.concat " "
         $"'{text}'"
-        
+

--- a/src/Finelines/Stages/YamlStage.fs
+++ b/src/Finelines/Stages/YamlStage.fs
@@ -13,7 +13,7 @@ type YamlStage = {
 
 type YamlStage with
     member this.AsString() =
-        let title = 
+        let title =
             this.Stage
             |> Option.map (fun stage -> $"- stage: {format (Text stage)}")
             |> Option.defaultValue "- stage:"
@@ -22,11 +22,11 @@ type YamlStage with
             this.DisplayName
             |> Option.map (fun name -> $"displayName: {format (Text name)}")
 
-        let condition = 
+        let condition =
             this.Condition
-            |> Option.map (fun condition -> $"condition: {format (Text condition)}")
+            |> Option.map (fun condition -> $"condition: {format (ConditionExpression condition)}")
 
-        let jobs = 
+        let jobs =
             this.Jobs
             |> List.map (fun job -> job.AsString())
             |> String.concat $"{br}{br}"

--- a/tests/Finelines.UnitTests/Stages/YamlStageTests.fs
+++ b/tests/Finelines.UnitTests/Stages/YamlStageTests.fs
@@ -7,7 +7,7 @@ open Finelines.Jobs
 open Swensen.Unquote
 
 [<Fact>]
-let ``Formats yaml stage`` () = 
+let ``Formats yaml stage`` () =
     let yaml = {
         Stage = Some "stage1"
         DisplayName = Some "Awesome stage"
@@ -45,11 +45,11 @@ let ``Formats yaml stage`` () =
             }
         ]
     }
-    
+
     let expected = "\
 - stage: stage1
   displayName: Awesome stage
-  condition: 'always()'
+  condition: always()
   jobs:
   - job:
     steps:
@@ -68,7 +68,7 @@ let ``Formats yaml stage`` () =
     test <@ actual = expected @>
 
 [<Fact>]
-let ``Formats yaml stage - no name`` () = 
+let ``Formats yaml stage - no name`` () =
     let yaml = {
         Stage = None
         DisplayName = Some "Awesome stage"
@@ -106,7 +106,7 @@ let ``Formats yaml stage - no name`` () =
             }
         ]
     }
-    
+
     let expected = "\
 - stage:
   displayName: Awesome stage
@@ -128,7 +128,7 @@ let ``Formats yaml stage - no name`` () =
     test <@ actual = expected @>
 
 [<Fact>]
-let ``Formats yaml stage - no display name`` () = 
+let ``Formats yaml stage - no display name`` () =
     let yaml = {
         Stage = Some "stage1"
         DisplayName = None
@@ -166,7 +166,7 @@ let ``Formats yaml stage - no display name`` () =
             }
         ]
     }
-    
+
     let expected = "\
 - stage: stage1
   jobs:


### PR DESCRIPTION
This removes wrapping single-quotes around condition expressions.